### PR TITLE
Add lodash to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "keywords": ["logging", "sysadmin", "tools", "winston", "journald", "systemd", "log", "logger"],
   "dependencies": {
+    "lodash": "^4.17.4",
     "systemd-journald": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
`winston-journald` uses `lodash` in its code, so include it in the dependency tree.