### PR TITLE
Use systemd-journald's metadata facilities

### DIFF
--- a/lib/winston-journald.js
+++ b/lib/winston-journald.js
@@ -59,17 +59,6 @@ Journald.prototype.log = function (level, msg, event_meta, callback) {
   var minLevel = lodash.find(levels, {winstonName: this.level});
   if(wantedLevel && minLevel && wantedLevel.level <= minLevel.level) {
     if (typeof journald[wantedLevel.journaldName] === 'function') {
-      if(typeof msg === 'object'){
-        msg = JSON.stringify(msg);
-      }
-      if(event_meta) {
-        if (typeof event_meta === 'object') {
-          event_meta = JSON.stringify(event_meta);
-        }
-        if(event_meta !== '{}') {
-          msg = msg + ' --- metadata: ' + event_meta;
-        }
-      }
       journald[wantedLevel.journaldName](msg, event_meta, callback);
     } else {
       callback(wantedLevel.journaldName + ' is not a correct level name');


### PR DESCRIPTION
Systemd's journal has metadata built into it. This change passes the
metadata that is provided to Winston directly into systemd-journald so
that the metadata is logged using the systemd journal's native metadata
facilities.