### PR TITLE
Update dependencies to allow adding default fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,11 @@ and a File is overkill.
 
   winston.add(winston.transports.Journald, options);
 ```
-options parameter (optionnal) can contains 'level' attribute, describing the minimum level used to send logs to journald. For example is you set options.level to 'info' all logs will be sent to journald but the 'debug' ones.
+
+The `options` parameter (optional) can contain the following attributes:
+* `level`: describing the minimum level used to send logs to journald. For example is you set options.level to `info` all logs will be sent to journald but the `debug` ones.
+* `concatMetaToMessage`: Concatenate the event meta data to the message.
+* `fields`: Default fields passed to [node-sytemd-journald](https://github.com/jue89/node-systemd-journald) when creating a new logger instance. This can be used to set the `SYSLOG_FACILITY` and `SYSLOG_IDENTIFIER` fields.
 
 ## Installation
 

--- a/lib/winston-journald.js
+++ b/lib/winston-journald.js
@@ -32,9 +32,13 @@ var Journald = exports.Journald = function (options) {
   if(options && !options.level){
     options.level = 'debug';
   }
+  if(options && !options.fields){
+    options.fields = {};
+  }
   this.options = options || {level: 'debug'};
   Transport.call(this, this.options);
   this.name = 'journald';
+  this.journald = new journald(this.options.fields)
 };
 
 /**
@@ -60,7 +64,7 @@ Journald.prototype.log = function (level, msg, event_meta, callback) {
   var wantedLevel = lodash.find(levels, {winstonName: level});
   var minLevel = lodash.find(levels, {winstonName: this.level});
   if(wantedLevel && minLevel && wantedLevel.level <= minLevel.level) {
-    if (typeof journald[wantedLevel.journaldName] === 'function') {
+    if (typeof this.journald[wantedLevel.journaldName] === 'function') {
       if(typeof msg === 'object' && !(msg instanceof Error)){
         msg = JSON.stringify(msg);
       }
@@ -75,7 +79,7 @@ Journald.prototype.log = function (level, msg, event_meta, callback) {
           msg = msg + ' --- metadata: ' + event_meta_str;
         }
       }
-      journald[wantedLevel.journaldName](msg, event_meta, callback);
+      this.journald[wantedLevel.journaldName](msg, event_meta, callback);
     } else {
       callback(wantedLevel.journaldName + ' is not a correct level name');
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "keywords": ["logging", "sysadmin", "tools", "winston", "journald", "systemd", "log", "logger"],
   "dependencies": {
     "lodash": "^4.17.4",
-    "systemd-journald": "^1.2.0"
+    "systemd-journald": "^1.3.0"
   },
   "devDependencies": {
     "winston": ">=1.1.1 <3.0.0",


### PR DESCRIPTION
This allows to add fields which will be applied to all the messages sent to journald.

It allows to define the syslog facility and syslog identifier when the logs are then forwarded to syslog.