### PR TITLE
winston-journald ignores winston's logging levels

### DIFF
--- a/lib/winston-journald.js
+++ b/lib/winston-journald.js
@@ -15,10 +15,13 @@ var util = require('util'),
   journald = require('systemd-journald');
 
 var levels =  [
+  { journaldName: 'debug', winstonName: 'silly', level: 8 },
   { journaldName: 'debug', winstonName: 'debug', level: 7 },
   { journaldName: 'info', winstonName: 'info', level: 6 },
   { journaldName: 'notice', winstonName: 'notice', level: 5 },
+  { journaldName: 'notice', winstonName: 'verbose', level: 5 },
   { journaldName: 'warning', winstonName: 'warning', level: 4 },
+  { journaldName: 'warning', winstonName: 'warn', level: 4 },
   { journaldName: 'err', winstonName: 'error', level: 3 },
   { journaldName: 'crit', winstonName: 'crit', level: 2 },
   { journaldName: 'alert', winstonName: 'alert', level: 1 },


### PR DESCRIPTION
so allow both syslog & npm levels