### PR TITLE
Upgrade version of systemd-journald

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "keywords": ["logging", "sysadmin", "tools", "winston", "journald", "systemd", "log", "logger"],
   "dependencies": {
     "lodash": "^4.17.4",
-    "systemd-journald": "^1.3.0"
+    "systemd-journald": "^1.4.0"
   },
   "devDependencies": {
     "winston": ">=1.1.1 <3.0.0",


### PR DESCRIPTION
Systemd-journald 1.3.0 relied on an old version of nan, which does
not work correctly on Node 10